### PR TITLE
Close connections dropped by the client instead of leaking them

### DIFF
--- a/server.c
+++ b/server.c
@@ -115,8 +115,10 @@ static void response_error(uv_handle_t*, int, const char*, const char*);
 
 static void
 destroy_request(http_request* request, int close_handle) {
-  if (close_handle && request->handle) {
-    uv_close((uv_handle_t*) request->handle, on_close);
+  if (request->handle) {
+    request->handle->data = NULL;
+    if (close_handle)
+      uv_close(request->handle, on_close);
   }
   free(request);
 }
@@ -398,14 +400,11 @@ on_read(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
   if (nread < 0) {
     if (buf->base)
       free(buf->base);
-    /*
-    uv_shutdown_t* shutdown_req = (uv_shutdown_t*) malloc(sizeof(uv_shutdown_t));
-    if (shutdown_req == NULL) {
-      fprintf(stderr, "Allocate error\n");
-      return;
-    }
-    uv_shutdown(shutdown_req, stream, on_shutdown);
-    */
+    /* A connection with no request in flight has no other owner, so nothing
+     * else would ever close it.  One that does is closed by the request or
+     * response that owns it, once its write fails. */
+    if (stream->data == NULL && !uv_is_closing((uv_handle_t*) stream))
+      uv_close((uv_handle_t*) stream, on_close);
     return;
   }
 
@@ -542,6 +541,8 @@ on_connection(uv_stream_t* server, int status) {
     fprintf(stderr, "Allocate error: %s\n", strerror(errno));
     return;
   }
+  /* No request in flight yet; see on_read(). */
+  stream->data = NULL;
 
   r = uv_tcp_init(loop, (uv_tcp_t*) stream);
   if (r) {

--- a/test/smoke.py
+++ b/test/smoke.py
@@ -185,6 +185,25 @@ def main():
         s.close()
         check("two requests on one connection", got, [True, True])
 
+        print("not leaking connections")
+        # A client that connects and goes away leaves no request in flight, so
+        # nothing but on_read() can close the handle.
+        fds = os.path.join("/proc", str(proc.pid), "fd")
+        if os.path.isdir(fds):
+            before = len(os.listdir(fds))
+            for _ in range(40):
+                s = socket.socket()
+                s.connect(("127.0.0.1", port))
+                s.close()
+            time.sleep(0.5)
+            for _ in range(20):
+                body(port, b"/index.html")
+            time.sleep(0.5)
+            grew = len(os.listdir(fds)) - before
+            check("descriptors reclaimed after clients disconnect", grew < 10, True)
+        else:
+            print("  skip  descriptor check (no /proc)")
+
         print("still alive")
         check("server survived", proc.poll(), None)
         check("serves after all of the above", body(port, b"/index.html"), b"ROOT-INDEX\n")


### PR DESCRIPTION
`on_read()` returned without closing the handle when `nread < 0`, and the shutdown code that would have done it was commented out. A connection is only ever closed by the request or response that owns it, so a client that goes away before sending a request left the `uv_tcp_t` and its descriptor alive forever.

Measured against master, counting `/proc/<pid>/fd`:

```
just started                        13 fds
after 50 x (connect, close)         63 fds
after 50 more                      113 fds
after 50 completed requests        113 fds   <- completed requests are fine
```

So any client can burn one descriptor per TCP connection without sending a byte, until the server runs out.

The fix needs an owner check, because closing unconditionally would free a handle that an in-flight response still points at. `stream->data` already held the in-flight request but was never cleared, so it now means exactly that: `on_connection()` initialises it to `NULL` (`malloc` left it uninitialised), `destroy_request()` clears it, and `on_read()` closes the handle only when it is `NULL`. A connection that does have a request in flight is still closed by that request once its write fails.

Verified that disconnecting mid-transfer does not regress into a use-after-free: 90 clients dropping an 8 MB transfer at various points, under ASan and UBSan, leaves no diagnostics, no descriptor growth and the server still serving. The smoke test now fails on master and passes here.