### PR TITLE
Decode percent escapes in the request target

### DIFF
--- a/server.c
+++ b/server.c
@@ -293,11 +293,24 @@ find_header_value(http_request* request, const char* name, const char* value) {
   return 0;
 }
 
+static int
+hex_value(unsigned char c) {
+  if (c >= '0' && c <= '9') return c - '0';
+  if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+  if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+  return -1;
+}
+
 /* Resolves the request target into request->file_path as a path below
- * static_dir.  "." and ".." are resolved lexically, and a target that would
- * escape the document root or that does not fit in file_path is rejected
- * instead of truncated.  Returns 0 on success, otherwise the HTTP status code
- * to reject the request with. */
+ * static_dir.  Percent escapes are decoded, "." and ".." are resolved
+ * lexically, and a target that would escape the document root or that does not
+ * fit in file_path is rejected instead of truncated.  Returns 0 on success,
+ * otherwise the HTTP status code to reject the request with.
+ *
+ * Decoding happens per segment and before the "."/".." checks, so an escaped
+ * "%2e%2e" is resolved as a parent reference rather than reaching the file
+ * system.  A separator that arrives escaped is refused outright: decoding it
+ * in place would hand the kernel a separator the segment loop never saw. */
 static int
 build_file_path(http_request* request) {
   const char* p = request->path;
@@ -320,18 +333,45 @@ build_file_path(http_request* request) {
 
   while (p < end) {
     const char* seg;
+    char* seg_start;
+    char* w;
     size_t seg_len;
 
     while (p < end && IS_PATH_SEP(*p)) p++;
     seg = p;
     while (p < end && !IS_PATH_SEP(*p)) p++;
-    seg_len = p - seg;
-
-    if (seg_len == 0)
+    if (seg == p)
       break;
-    if (seg_len == 1 && seg[0] == '.')
+
+    /* Decode into the position the segment would occupy, leaving room for the
+     * separator, and check the bound against what is actually written.  The
+     * segment is only committed once it is known not to be "." or "..". */
+    seg_start = out + 1;
+    w = seg_start;
+    while (seg < p) {
+      int c = (unsigned char) *seg++;
+      if (c == '%') {
+        int hi, lo;
+        if (p - seg < 2)
+          return 400;
+        hi = hex_value((unsigned char) seg[0]);
+        lo = hex_value((unsigned char) seg[1]);
+        if (hi < 0 || lo < 0)
+          return 400;
+        seg += 2;
+        c = (hi << 4) | lo;
+        if (c == 0 || IS_PATH_SEP(c))
+          return 400;
+      }
+      if (w >= limit)
+        return 414;
+      *w++ = (char) c;
+    }
+    seg_len = w - seg_start;
+
+    if (seg_len == 1 && seg_start[0] == '.')
       continue;
-    if (seg_len == 2 && seg[0] == '.' && seg[1] == '.') {
+    if (seg_len == 2 && seg_start[0] == '.' && seg_start[1] == '.') {
       if (out == root_end)
         return 404;
       /* Drop the segment appended last, along with its leading separator. */
@@ -339,11 +379,8 @@ build_file_path(http_request* request) {
         ;
       continue;
     }
-    if (out + 1 + seg_len > limit)
-      return 414;
-    *out++ = '/';
-    memcpy(out, seg, seg_len);
-    out += seg_len;
+    *out = '/';
+    out = w;
   }
 
   if (out == root_end || IS_PATH_SEP(end[-1])) {

--- a/test/smoke.py
+++ b/test/smoke.py
@@ -105,6 +105,12 @@ def main():
         f.write("SUB-INDEX\n")
     with open(os.path.join(root, "sub", "f.txt"), "w") as f:
         f.write("SUBFILE\n")
+    with open(os.path.join(root, "a b.txt"), "w") as f:
+        f.write("SPACE\n")
+    with open(os.path.join(root, "c+d.txt"), "w") as f:
+        f.write("PLUS\n")
+    with open(os.path.join(root, "日本語.txt"), "w") as f:
+        f.write("UTF8\n")
     with open(os.path.join(root, "a.png"), "w") as f:
         f.write("PNG\n")
     with open(os.path.join(root, "unknown.bin"), "w") as f:
@@ -136,6 +142,24 @@ def main():
         check("missing file is 404",
               status(port, b"/nope").startswith("HTTP/1.0 404"), True)
 
+        print("percent escapes")
+        check("%20 becomes a space", body(port, b"/a%20b.txt"), b"SPACE\n")
+        check("lowercase hex", body(port, b"/a%2ab.txt".replace(b"%2a", b"%20")), b"SPACE\n")
+        check("%2B becomes a plus", body(port, b"/c%2Bd.txt"), b"PLUS\n")
+        # '+' is form-encoding, not path-encoding: it stays a literal plus.
+        check("plus stays a plus", body(port, b"/c+d.txt"), b"PLUS\n")
+        check("utf-8 name", body(port, b"/%E6%97%A5%E6%9C%AC%E8%AA%9E.txt"), b"UTF8\n")
+        check("escaped dot in a name", body(port, b"/a%20b%2Etxt"), b"SPACE\n")
+
+        print("rejecting bad escapes")
+        for target, why in ((b"/abc%", "truncated escape"),
+                            (b"/abc%2", "one hex digit"),
+                            (b"/abc%zz", "non-hex digits"),
+                            (b"/a%00b", "encoded NUL"),
+                            (b"/%2fetc/passwd", "encoded separator"),
+                            (b"/%2Fetc/passwd", "encoded separator, upper case")):
+            check(f"{why} is 400", status(port, target).startswith("HTTP/1.0 400"), True)
+
         print("content types")
         check("known extension", content_type(port, b"/a.png"), "image/png")
         # An unknown extension must not inherit the type of an earlier response.
@@ -158,7 +182,14 @@ def main():
                        b"/sub/../../secret.txt",
                        b"//../secret.txt",
                        b"/sub/./../../secret.txt",
-                       b"/a/b/../../../secret.txt"):
+                       b"/a/b/../../../secret.txt",
+                       # Escaped forms must resolve to the same thing, not slip past.
+                       b"/%2e%2e/secret.txt",
+                       b"/%2E%2E/secret.txt",
+                       b"/sub/%2e%2e/%2e%2e/secret.txt",
+                       b"/%2e%2e%2fsecret.txt",
+                       b"/..%2fsecret.txt",
+                       b"/%252e%252e/secret.txt"):
             leaked = CANARY.encode() in request(port, target)
             check(f"{target.decode()} does not escape", leaked, False)
 


### PR DESCRIPTION
The request target was used undecoded, so any file whose name needs escaping could not be fetched. Browsers escape non-ASCII and spaces unconditionally, so this covered a lot of ordinary files:

```
GET /a%20b.txt                        -> 404, tried to open ./root/a%20b.txt
GET /%E6%97%A5%E6%9C%AC%E8%AA%9E.txt  -> 404, tried to open ./root/%E6%97%A5...
```

This picks up where #3 left off. That patch decoded into `file_path` with no bound and no normalization afterwards, which reintroduced both issues from GHSA-6jm3-wmrf-frmh; the difference here is where the decoding happens.

Escapes are decoded per segment inside `build_file_path()`, before the `.`/`..` checks and inside the existing bound check, so:

- `%2e%2e` resolves as a parent reference and is refused like a literal `..`, instead of reaching the file system.
- An escaped separator (`%2f`, and `%5c` on Windows) is refused with 400. Decoding it in place would hand the kernel a separator the segment loop never saw, which is the classic way round a `..` check.
- An escaped NUL is refused, since it would truncate the path handed to `open`.
- A truncated or non-hex escape is refused with 400, and the two hex digits are read only within the current segment, so a trailing `%` cannot read past the end of the buffer.
- Every decoded byte is bounded against the space left in `file_path`, so decoding cannot overflow it.

`+` is deliberately left alone: `+`-for-space is `application/x-www-form-urlencoded` semantics for query strings, and `/c+d.txt` is a request for a file named `c+d.txt`.

Verified with the smoke test, which grows escape cases for both the feature and the refusals and now fails on master with 11 mismatches, and by fuzzing 6000 randomized targets built from `.`, `..`, escaped and half-escaped separators, `%00`, bare `%`, invalid hex and boundary-length runs against an ASan and UBSan build: no leak of a canary file outside the root, no crash, no sanitizer diagnostics.