### PR TITLE
Serve one request per connection at a time to stop closing it twice

### DIFF
--- a/server.c
+++ b/server.c
@@ -113,12 +113,21 @@ static void on_alloc(uv_handle_t*, size_t, uv_buf_t*);
 static void on_fs_read(uv_fs_t*);
 static void response_error(uv_handle_t*, int, const char*, const char*);
 
+/* Closing a handle twice aborts inside libuv, and with asserts off links it
+ * into the closing queue twice so on_close() frees it twice, so every close
+ * goes through here. */
+static void
+close_connection(uv_handle_t* handle) {
+  if (handle && !uv_is_closing(handle))
+    uv_close(handle, on_close);
+}
+
 static void
 destroy_request(http_request* request, int close_handle) {
   if (request->handle) {
     request->handle->data = NULL;
     if (close_handle)
-      uv_close(request->handle, on_close);
+      close_connection(request->handle);
   }
   free(request);
 }
@@ -440,8 +449,8 @@ on_read(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
     /* A connection with no request in flight has no other owner, so nothing
      * else would ever close it.  One that does is closed by the request or
      * response that owns it, once its write fails. */
-    if (stream->data == NULL && !uv_is_closing((uv_handle_t*) stream))
-      uv_close((uv_handle_t*) stream, on_close);
+    if (stream->data == NULL)
+      close_connection((uv_handle_t*) stream);
     return;
   }
 
@@ -450,14 +459,23 @@ on_read(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
     return;
   }
 
+  /* One request per connection at a time.  Anything arriving while one is in
+   * flight -- a pipelined request, or garbage -- is ignored: serving it would
+   * give the connection a second owner, and whichever finished first would
+   * close the handle out from under the other.  A second request in a single
+   * read is already dropped, since the target is parsed only once. */
+  if (stream->data != NULL) {
+    free(buf->base);
+    return;
+  }
+
   http_request* request = calloc(1, sizeof(http_request));
   if (request == NULL) {
     free(buf->base);
     fprintf(stderr, "Allocate error: %s\n", strerror(errno));
-    uv_close((uv_handle_t*) stream, on_close);
+    close_connection((uv_handle_t*) stream);
     return;
   }
-  stream->data = request;
 
   request->handle = (uv_handle_t*) stream;
 
@@ -477,9 +495,11 @@ on_read(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
     free(request);
     free(buf->base);
     fprintf(stderr, "Invalid request\n");
-    uv_close((uv_handle_t*) stream, on_close);
+    close_connection((uv_handle_t*) stream);
     return;
   }
+  /* From here on this request owns the connection. */
+  stream->data = request;
   /*
   int cl = content_length(request);
   if (cl >= 0 && cl < buf->len - nparsed) {
@@ -608,7 +628,7 @@ on_connection(uv_stream_t* server, int status) {
   r = uv_read_start(stream, on_alloc, on_read);
   if (r) {
     fprintf(stderr, "Read error: %s: %s\n", uv_err_name(r), uv_strerror(r));
-    uv_close((uv_handle_t*) stream, on_close);
+    close_connection((uv_handle_t*) stream);
   }
 }
 

--- a/test/smoke.py
+++ b/test/smoke.py
@@ -113,6 +113,9 @@ def main():
         f.write("UTF8\n")
     with open(os.path.join(root, "a.png"), "w") as f:
         f.write("PNG\n")
+    # Bigger than WRITE_BUF_SIZE, so serving it spans several loop iterations.
+    with open(os.path.join(root, "big.bin"), "wb") as f:
+        f.write(b"X" * (2 * 1024 * 1024))
     with open(os.path.join(root, "unknown.bin"), "w") as f:
         f.write("BIN\n")
     # Outside the document root: must never be served.
@@ -215,6 +218,37 @@ def main():
             got.append(marker in data)
         s.close()
         check("two requests on one connection", got, [True, True])
+
+        print("surviving overlapping requests on one connection")
+        # A second request, or garbage, arriving while a response is streaming
+        # used to give the connection a second owner and get it closed twice.
+        for name, payloads in (
+                ("garbage during a transfer",
+                 [b"GET /big.bin HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n",
+                  b"GARBAGE\r\n\r\n"]),
+                ("second request during a transfer",
+                 [b"GET /big.bin HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n",
+                  b"GET /index.html HTTP/1.1\r\nHost: x\r\n\r\n"]),
+                ("two misses back to back",
+                 [b"GET /nope1 HTTP/1.1\r\nHost: x\r\n\r\n",
+                  b"GET /nope2 HTTP/1.1\r\nHost: x\r\n\r\n"]),
+                ("pipelined in one write",
+                 [b"GET /nope1 HTTP/1.1\r\nHost: x\r\n\r\n"
+                  b"GET /nope2 HTTP/1.1\r\nHost: x\r\n\r\n"]),
+        ):
+            for _ in range(5):
+                try:
+                    s = socket.socket()
+                    s.settimeout(2)
+                    s.connect(("127.0.0.1", port))
+                    for payload in payloads:
+                        s.sendall(payload)
+                    time.sleep(0.02)
+                    s.close()
+                except OSError:
+                    pass
+            time.sleep(0.3)
+            check(f"alive after {name}", proc.poll(), None)
 
         print("not leaking connections")
         # A client that connects and goes away leaves no request in flight, so


### PR DESCRIPTION
A second request, or any garbage, arriving on a connection while a response is still streaming crashes the server. Against master, each of these kills it with SIGSEGV:

```
alive after garbage during a transfer:          got -11
alive after second request during a transfer:   got -11
alive after two misses back to back:            got -11
alive after pipelined in one write:             got -11
```

Under ASan it reports `attempting double-free`, and the server log shows the mechanism:

```
Invalid request            <- on_read() closes the handle unconditionally
Write error: ECANCELED     <- that close cancels the in-flight write
                              -> on_write() sees an error -> destroy_response()
                              -> a second close -> on_close() runs twice -> double free
```

The underlying problem is that a connection can end up with two owners. `on_read()` never checked whether a request was already in flight: it built a second `http_request` for the same `uv_tcp_t`, overwrote `stream->data`, and every terminal path closes the handle, so whichever chain finished first freed it under the other.

Two changes. `on_read()` now ignores anything that arrives while a request is in flight, so a connection has exactly one owner at a time — a second request in a single read was already dropped, since the target is parsed only once, so this makes the two-read case behave the same as the one-read case instead of crashing. And every close now goes through `close_connection()`, which skips a handle that is already closing, so no remaining path can double it.

`stream->data` is also now assigned only after the request parses, so the parse-failure path no longer leaves it dangling at freed memory.

Verified with the four cases above added to the smoke test, which fail on master with SIGSEGV and pass here on both a plain build and an ASan/UBSan build. Also stress tested with 12 concurrent clients making 60 connections each, interleaving large transfers, pipelined requests, truncated requests, binary garbage, traversal attempts and over-long targets: no sanitizer diagnostics, no refused connections, descriptors back to the baseline, server still serving.