### PR TITLE
Reject anything that is not a regular file

### DIFF
--- a/server.c
+++ b/server.c
@@ -72,6 +72,10 @@
 #define S_IREAD _S_IREAD
 #endif
 
+#ifndef S_ISREG
+#define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
+#endif
+
 #ifdef _WIN32
 # define INVALID_FD (INVALID_HANDLE_VALUE)
 #else
@@ -133,13 +137,18 @@ destroy_request(http_request* request, int close_handle) {
 }
 
 static void
+close_file(uv_file fd) {
+  uv_fs_t close_req;
+  uv_fs_close(loop, &close_req, fd, NULL);
+  uv_fs_req_cleanup(&close_req);
+}
+
+static void
 destroy_response(http_response* response, int close_handle) {
   if (response->pbuf) free(response->pbuf);
   if (response->request) destroy_request(response->request, close_handle);
-  if (response->fd != -1) {
-    uv_fs_t close_req;
-    uv_fs_close(loop, &close_req, (uv_file) response->fd, NULL);
-  }
+  if (response->fd != -1)
+    close_file((uv_file) response->fd);
   free(response);
 }
 
@@ -185,13 +194,25 @@ on_fs_open(uv_fs_t* req) {
   int r = uv_fs_fstat(loop, &stat_req, result, NULL);
   if (r < 0) {
     fprintf(stderr, "Stat error: %s: %s: %s\n", request->file_path, uv_err_name(r), uv_strerror(r));
+    uv_fs_req_cleanup(&stat_req);
+    close_file((uv_file) result);
     response_error(request->handle, 404, "Not Found", NULL);
     destroy_request(request, 1);
     return;
   }
 
   uint64_t response_size = stat_req.statbuf.st_size;
+  int regular = S_ISREG(stat_req.statbuf.st_mode);
   uv_fs_req_cleanup(&stat_req);
+
+  /* Opening a directory succeeds on Linux, but reading it fails afterwards,
+   * by which point a 200 and a Content-Length have already gone out. */
+  if (!regular) {
+    close_file((uv_file) result);
+    response_error(request->handle, 404, "Not Found", NULL);
+    destroy_request(request, 1);
+    return;
+  }
 
   const char* ctype = "application/octet-stream";
   const char* dot = request->file_path;
@@ -208,6 +229,7 @@ on_fs_open(uv_fs_t* req) {
   http_response* response = calloc(1, sizeof(http_response));
   if (response == NULL) {
     fprintf(stderr, "Allocate error: %s\n", strerror(r));
+    close_file((uv_file) result);
     response_error(request->handle, 404, "Not Found", NULL);
     destroy_request(request, 1);
     return;

--- a/test/smoke.py
+++ b/test/smoke.py
@@ -172,6 +172,16 @@ def main():
         check("unknown extension again",
               content_type(port, b"/unknown.bin"), "application/octet-stream")
 
+        print("rejecting anything that is not a regular file")
+        # Opening a directory succeeds on Linux; reading it fails only after a
+        # 200 and a Content-Length have already been written.
+        for target in (b"/sub", b"/.", b"/sub/.."):
+            data = request(port, target)
+            check(f"{target.decode()} gives one status line",
+                  data.count(b"HTTP/1."), 1)
+        check("directory without a slash is 404",
+              status(port, b"/sub").startswith("HTTP/1.0 404"), True)
+
         print("rejecting bad targets")
         # An over-long target must be refused, not copied into a fixed buffer.
         check("over-long target is 414",


### PR DESCRIPTION
`uv_fs_open` succeeds on a directory on Linux and nothing checked the mode, so requesting one emitted a response with two status lines. Against master, `GET /sub` where `sub` is a directory:

```
HTTP/1.1 200 OK
Content-Length: 4096
Content-Type: application/octet-stream
Connection: close

HTTP/1.0 500 Internal Server Error
Content-Length: 21
Content-Type: text/plain; charset=UTF-8;

Internal Server Error
```

The 200 and its `Content-Length` are written before the file is ever read; the read then fails with `EISDIR` and `on_fs_read()` appends a second status line as the body — 34 bytes where the header promised 4096. Once headers are committed the only correct failure is to drop the connection, never to write another status line.

`on_fs_open()` already calls `uv_fs_fstat`, so this checks `S_ISREG` on the result and answers 404 for anything else, before any part of the response goes out. That also covers fifos and device files, which would otherwise be opened and streamed with a bogus length.

While in these error paths, the descriptor `uv_fs_open` returned is now closed on each of them — the `fstat` failure and the two allocation failures previously returned without closing it. To be clear about what is demonstrated: only the double status line is externally reproducible. I could not trigger the descriptor leaks from outside, since they need `fstat` on a valid descriptor to fail or an allocation to fail, and I measured no descriptor growth on master over 60 directory requests because those take the success path. They are fixed as code defects, not as observed leaks.

`destroy_response()` now also calls `uv_fs_req_cleanup` on its close request, which libuv documents as required.

The smoke test grows a check that a request for a directory yields exactly one status line and a 404; it fails on master with `got 2, want 1`.