### PR TITLE
Write the response header from the response, not from the stack

### DIFF
--- a/server.c
+++ b/server.c
@@ -109,6 +109,7 @@ btime(int f) {
 #endif
 
 static void on_write(uv_write_t*, int);
+static void on_write_header(uv_write_t*, int);
 static void on_write_error_free_buf(uv_write_t*, int);
 static void on_read(uv_stream_t*, ssize_t, const uv_buf_t*);
 static void on_close(uv_handle_t*);
@@ -145,6 +146,7 @@ close_file(uv_file fd) {
 
 static void
 destroy_response(http_response* response, int close_handle) {
+  if (response->header) free(response->header);
   if (response->pbuf) free(response->pbuf);
   if (response->request) destroy_request(response->request, close_handle);
   if (response->fd != -1)
@@ -260,27 +262,52 @@ on_fs_open(uv_fs_t* req) {
       response_size,
       ctype,
       (request->keep_alive ? "keep-alive" : "close"));
-  uv_buf_t buf = uv_buf_init(bufline, nbuf);
-
-#ifndef _WIN32
-  r = uv_try_write((uv_stream_t*) request->handle, &buf, 1);
-  if (r == 0) {
-    fprintf(stderr, "Write error\n");
+  if (nbuf < 0 || (size_t) nbuf >= sizeof(bufline)) {
+    fprintf(stderr, "Header too long: %s\n", request->file_path);
+    response_error(request->handle, 500, "Internal Server Error", NULL);
     destroy_response(response, 1);
     return;
   }
-#else
-  r = uv_write(&response->write_req, (uv_stream_t*) request->handle, &buf, 1, NULL);
+
+  /* uv_write() keeps the buffer, so the header cannot live on this frame; it
+   * also has its own request, because response->write_req is still in use for
+   * the body chunks. */
+  response->header = malloc(nbuf);
+  if (response->header == NULL) {
+    fprintf(stderr, "Allocate error: %s\n", strerror(errno));
+    response_error(request->handle, 500, "Internal Server Error", NULL);
+    destroy_response(response, 1);
+    return;
+  }
+  memcpy(response->header, bufline, nbuf);
+  response->header_req.data = response;
+
+  uv_buf_t buf = uv_buf_init(response->header, nbuf);
+  r = uv_write(&response->header_req, (uv_stream_t*) request->handle, &buf, 1, on_write_header);
   if (r) {
     fprintf(stderr, "Write error: %s: %s\n", uv_err_name(r), uv_strerror(r));
     destroy_response(response, 1);
+  }
+}
+
+/* The body is only read once the header has actually gone out, so a partial or
+ * failed header write cannot be followed by body bytes. */
+static void
+on_write_header(uv_write_t* req, int status) {
+  http_response* response = (http_response*) req->data;
+
+  free(response->header);
+  response->header = NULL;
+
+  if (status != 0) {
+    fprintf(stderr, "Write error: %s: %s\n", uv_err_name(status), uv_strerror(status));
+    destroy_response(response, 1);
     return;
   }
-#endif
 
-  r = uv_fs_read(loop, &response->read_req, result, &response->buf, 1, -1, on_fs_read);
+  int r = uv_fs_read(loop, &response->read_req, response->fd, &response->buf, 1, -1, on_fs_read);
   if (r) {
-    response_error(request->handle, 500, "Internal Server Error", NULL);
+    fprintf(stderr, "File read error: %s: %s\n", uv_err_name(r), uv_strerror(r));
     destroy_response(response, 1);
   }
 }

--- a/server.h
+++ b/server.h
@@ -47,7 +47,9 @@ typedef struct _http_request {
 typedef struct {
   uv_file fd;
   uv_write_t write_req;
+  uv_write_t header_req;
   uv_fs_t read_req;
+  char* header;
   char* pbuf;
   uv_buf_t buf;
   uv_handle_t* handle;


### PR DESCRIPTION
The response header was built in a 1024-byte local of `on_fs_open()` and then handed to libuv, which is only safe by accident on one of the two branches.

On Windows it was passed to `uv_write()` with a `NULL` callback. `uv_write()` does not copy the buffer, so libuv retains a pointer into a stack frame that is gone as soon as `on_fs_open()` returns, and with no callback there is no point at which the buffer could be known to be free. It also reused `response->write_req`, which `on_fs_read()` submits again for the body — the same request linked into the stream's write queue twice.

On POSIX it used `uv_try_write()` and checked only `r == 0`. That return does not happen for a non-empty buffer: `uv_try_write()` returns the byte count, or a negative error such as `UV_EAGAIN` when nothing can be sent immediately or `UV_EPIPE` on a dead stream. So the error branch was dead code and every real failure fell through, as did a short write. The body was then streamed regardless, so a backpressured or disconnecting client got a truncated header block followed by file bytes, or file bytes with no status line at all.

Now the header is copied into a buffer owned by the `http_response`, written with `uv_write()` on both platforms using its own `header_req`, and the body read is started from the write callback. So the buffer outlives the write, the two writes never share a request, short writes are libuv's problem rather than silently ignored, and body bytes cannot follow a header that did not go out. `snprintf` truncation is checked as well, instead of being passed to `uv_buf_init` as a length past the end of the buffer.

Verified with the smoke test on a plain build and on an ASan/UBSan build with LeakSanitizer left enabled, so the new allocation is checked for leaks on both the success and failure paths. Also stress tested with 12 concurrent clients making 50 connections each, mixing large transfers, garbage, traversal attempts, over-long targets and reads abandoned after 1 byte to force short writes: no diagnostics, descriptors back to baseline, server still serving.