### PR TITLE
Send no body for HEAD and refuse methods that are not implemented

### DIFF
--- a/server.c
+++ b/server.c
@@ -305,6 +305,12 @@ on_write_header(uv_write_t* req, int status) {
     return;
   }
 
+  /* A HEAD response is the header and nothing else. */
+  if (response->request->head_only) {
+    destroy_response(response, !response->request->keep_alive);
+    return;
+  }
+
   int r = uv_fs_read(loop, &response->read_req, response->fd, &response->buf, 1, -1, on_fs_read);
   if (r) {
     fprintf(stderr, "File read error: %s: %s\n", uv_err_name(r), uv_strerror(r));
@@ -457,6 +463,7 @@ respond_status(http_request* request, int status_code) {
   case 400: status = "Bad Request"; break;
   case 414: status = "URI Too Long"; break;
   case 500: status = "Internal Server Error"; break;
+  case 501: status = "Not Implemented"; break;
   default:
     status_code = 404;
     status = "Not Found";
@@ -468,7 +475,18 @@ respond_status(http_request* request, int status_code) {
 
 static void
 request_complete(http_request* request) {
-  int status = build_file_path(request);
+  int status;
+
+  if (request->method_len == 3 && !memcmp(request->method, "GET", 3))
+    request->head_only = 0;
+  else if (request->method_len == 4 && !memcmp(request->method, "HEAD", 4))
+    request->head_only = 1;
+  else {
+    respond_status(request, 501);
+    return;
+  }
+
+  status = build_file_path(request);
   if (status) {
     respond_status(request, status);
     return;

--- a/server.h
+++ b/server.h
@@ -40,6 +40,9 @@ typedef struct _http_request {
   const char* payload;
   size_t payload_len;
   int keep_alive;
+  /* method points into the read buffer, which is freed before the response is
+   * built, so what it was has to be recorded here. */
+  int head_only;
 
   char file_path[PATH_MAX];
 } http_request;

--- a/test/smoke.py
+++ b/test/smoke.py
@@ -35,9 +35,9 @@ def free_port():
     return port
 
 
-def request(port, target, connection=b"close", read_all=True):
+def request(port, target, method=b"GET", connection=b"close", read_all=True):
     """Send one request, return the whole response (headers and body)."""
-    req = (b"GET " + target + b" HTTP/1.1\r\nHost: localhost\r\n"
+    req = (method + b" " + target + b" HTTP/1.1\r\nHost: localhost\r\n"
            b"Connection: " + connection + b"\r\n\r\n")
     s = socket.socket()
     s.settimeout(5)
@@ -62,8 +62,8 @@ def content_type(port, target):
     return "<none>"
 
 
-def status(port, target):
-    data = request(port, target)
+def status(port, target, method=b"GET"):
+    data = request(port, target, method)
     if not data:
         return "<empty>"
     return data.split(b"\r\n", 1)[0].decode("latin-1")
@@ -162,6 +162,32 @@ def main():
                             (b"/%2fetc/passwd", "encoded separator"),
                             (b"/%2Fetc/passwd", "encoded separator, upper case")):
             check(f"{why} is 400", status(port, target).startswith("HTTP/1.0 400"), True)
+
+        print("methods")
+        s = socket.socket()
+        s.settimeout(2)
+        s.connect(("127.0.0.1", port))
+        s.sendall(b"HEAD /index.html HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n")
+        time.sleep(0.2)
+        s.sendall(b"GET /index.html HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n")
+        data = b""
+        for _ in range(8):
+            try:
+                chunk = s.recv(65536)
+            except socket.timeout:
+                break
+            if not chunk:
+                break
+            data += chunk
+        s.close()
+        # A body on the HEAD response desynchronizes a persistent connection:
+        # the client reads it as the start of the next response.
+        check("HEAD then GET yields two responses", data.count(b"HTTP/1."), 2)
+        check("HEAD sends no body",
+              data.split(b"\r\n\r\n")[1].startswith(b"HTTP/1."), True)
+        for method in (b"POST", b"DELETE", b"FROB"):
+            check(f"{method.decode()} is 501",
+                  status(port, b"/index.html", method).startswith("HTTP/1.0 501"), True)
 
         print("content types")
         check("known extension", content_type(port, b"/a.png"), "image/png")


### PR DESCRIPTION
The request method was parsed and then never looked at, so every method was served as a GET.

`HEAD` returned the full file body. On a persistent connection that desynchronizes the stream, because the client reads the body as the start of the next response. Against master:

```
HEAD /index.html  ->  HTTP/1.1 200 OK ... Content-Length: 4 ... \r\n\r\nidx\n
POST /index.html  ->  HTTP/1.1 200 OK, full body
DELETE /index.html -> HTTP/1.1 200 OK, full body
FROB /index.html  ->  HTTP/1.1 200 OK, full body
```

`GET` and `HEAD` are now the only methods accepted; anything else gets 501. 501 rather than 405 because the server implements no other method at all, for any resource, and 405 would oblige us to send an `Allow` header that `response_error()` has no way to add.

For HEAD the header is written and the response is torn down without reading the file, which is only safe now that the header write completes through a callback rather than being fired at a stack buffer — this depends on #11.

The method has to be recorded on the request as `head_only`, because `request->method` points into the read buffer and that is freed before the response is built.

Verified with smoke test cases that fail on master with four mismatches and pass here, on a plain build and on an ASan/UBSan build with LeakSanitizer enabled.