### PR TITLE
Match header names in full and Connection values per token

### DIFF
--- a/server.c
+++ b/server.c
@@ -326,12 +326,47 @@ on_shutdown(uv_shutdown_t* req, int status) {
 }
 */
 
+/* The received name has to match in full.  Comparing only as many bytes as
+ * arrived would make every prefix of the name match, so a header called "C"
+ * would answer for "Connection". */
+static int
+header_name_is(const struct phr_header* header, const char* name) {
+  size_t len = strlen(name);
+  return header->name_len == len && !strncasecmp(header->name, name, len);
+}
+
+/* Connection is a comma separated list of tokens, so a value has to be matched
+ * one token at a time rather than against the whole field. */
+static int
+header_has_token(const struct phr_header* header, const char* token) {
+  size_t token_len = strlen(token);
+  const char* p = header->value;
+  const char* end = p + header->value_len;
+
+  while (p < end) {
+    const char* start;
+    size_t len;
+
+    while (p < end && (*p == ' ' || *p == '\t' || *p == ','))
+      p++;
+    start = p;
+    while (p < end && *p != ',')
+      p++;
+    len = p - start;
+    while (len > 0 && (start[len - 1] == ' ' || start[len - 1] == '\t'))
+      len--;
+    if (len == token_len && !strncasecmp(start, token, token_len))
+      return 1;
+  }
+  return 0;
+}
+
 static int
 content_length(http_request* request) {
-  int i;
+  size_t i;
   char buf[16];
   for (i = 0; i < request->num_headers; i++)
-    if (!strncasecmp(request->headers[i].name, "content-length", request->headers[i].name_len)) {
+    if (header_name_is(&request->headers[i], "content-length")) {
       size_t len = request->headers[i].value_len;
       if (len >= sizeof(buf)) len = sizeof(buf) - 1;
       memcpy(buf, request->headers[i].value, len);
@@ -343,15 +378,15 @@ content_length(http_request* request) {
 
 static int
 find_header_value(http_request* request, const char* name, const char* value) {
-  int i;
+  size_t i;
   for (i = 0; i < request->num_headers; i++) {
 #ifdef DEBUG
     printf("%.*s: %.*s\n",
       (int) request->headers[i].name_len, request->headers[i].name,
       (int) request->headers[i].value_len, request->headers[i].value);
 #endif
-    if (!strncasecmp(request->headers[i].name, name, request->headers[i].name_len) &&
-        !strncasecmp(request->headers[i].value, value, request->headers[i].value_len))
+    if (header_name_is(&request->headers[i], name) &&
+        header_has_token(&request->headers[i], value))
       return 1;
   }
   return 0;

--- a/test/smoke.py
+++ b/test/smoke.py
@@ -163,6 +163,41 @@ def main():
                             (b"/%2Fetc/passwd", "encoded separator, upper case")):
             check(f"{why} is 400", status(port, target).startswith("HTTP/1.0 400"), True)
 
+        print("Connection header matching")
+
+        def conn(extra):
+            s = socket.socket()
+            s.settimeout(2)
+            try:
+                s.connect(("127.0.0.1", port))
+                s.sendall(b"GET /index.html HTTP/1.1\r\nHost: x\r\n" + extra + b"\r\n")
+                # Read only the header block: a keep-alive response leaves the
+                # connection open, so reading to EOF would just time out.
+                data = b""
+                while b"\r\n\r\n" not in data:
+                    chunk = s.recv(65536)
+                    if not chunk:
+                        break
+                    data += chunk
+            except OSError:
+                return "<error>"
+            finally:
+                s.close()
+            for line in data.split(b"\r\n"):
+                if line.lower().startswith(b"connection:"):
+                    return line.split(b":", 1)[1].strip().decode("latin-1").lower()
+            return "<none>"
+
+        check("Connection: keep-alive", conn(b"Connection: keep-alive\r\n"), "keep-alive")
+        check("Connection: close", conn(b"Connection: close\r\n"), "close")
+        check("mixed case", conn(b"Connection: Keep-Alive\r\n"), "keep-alive")
+        # A received name must match in full, not as a prefix of the one sought.
+        check("one letter header is not Connection", conn(b"C: k\r\n"), "close")
+        check("Conn is not Connection", conn(b"Conn: keep\r\n"), "close")
+        # Connection is a token list, so keep-alive counts among other tokens.
+        check("token among others", conn(b"Connection: keep-alive, TE\r\n"), "keep-alive")
+        check("token with padding", conn(b"Connection:  TE ,  keep-alive \r\n"), "keep-alive")
+
         print("methods")
         s = socket.socket()
         s.settimeout(2)


### PR DESCRIPTION
`find_header_value()` passed the *client supplied* lengths to `strncasecmp`:

```c
if (!strncasecmp(request->headers[i].name, name, request->headers[i].name_len) &&
    !strncasecmp(request->headers[i].value, value, request->headers[i].value_len))
```

So it asked whether the name being sought *starts with* the name that arrived, and likewise for the value. Both directions are wrong, and both are reachable from a request. Against master:

```
Connection: keep-alive       -> keep-alive   correct
C: k                         -> keep-alive   wrong, no Connection header was sent
Conn: keep                   -> keep-alive   wrong
Connection: keep-alive, TE   -> close        wrong, a legal token list is ignored
Connection:  TE ,  keep-alive -> close       wrong
```

A one byte header is enough to hold a connection open, since `strncasecmp("C", "Connection", 1)` is 0 and `strncasecmp("k", "keep-alive", 1)` is 0. In the other direction the comparison runs past the end of `"keep-alive"` for any longer value, so a client that sends more than one connection option is treated as if it asked to close.

Two helpers replace it. `header_name_is()` requires `name_len` to equal the sought name's length before comparing. `header_has_token()` walks the value as the comma separated list it is, trimming spaces and tabs around each token, and matches a token in full. `content_length()` had the identical name bug — it is currently only reachable from commented-out code, but it is fixed the same way rather than left as a trap.

The loop counters also become `size_t` to match `num_headers`.

This does not change the default when no `Connection` header is present; HTTP/1.1 still wrongly defaults to close, which is a separate fix.

Verified with smoke test cases that fail on master with four mismatches and pass here, plus the fuzzer and the analyzer baseline unchanged at 9.