### PR TITLE
Buffer a request head that arrives across several reads

### DIFF
--- a/server.c
+++ b/server.c
@@ -57,6 +57,10 @@
 
 #define WRITE_BUF_SIZE (8192/4)
 
+/* A request head can arrive in pieces, so it is buffered until complete. This
+ * caps how much a client can make us hold before it has sent a whole one. */
+#define MAX_REQUEST_HEAD (64 * 1024)
+
 /* Appended when the request target names a directory. */
 #define INDEX_FILE "index.html"
 
@@ -130,7 +134,9 @@ close_connection(uv_handle_t* handle) {
 static void
 destroy_request(http_request* request, int close_handle) {
   if (request->handle) {
-    request->handle->data = NULL;
+    http_connection* conn = (http_connection*) request->handle->data;
+    if (conn)
+      conn->request = NULL;
     if (close_handle)
       close_connection(request->handle);
   }
@@ -552,13 +558,15 @@ request_complete(http_request* request) {
 
 static void
 on_read(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
+  http_connection* conn = (http_connection*) stream->data;
+
   if (nread < 0) {
     if (buf->base)
       free(buf->base);
     /* A connection with no request in flight has no other owner, so nothing
      * else would ever close it.  One that does is closed by the request or
      * response that owns it, once its write fails. */
-    if (stream->data == NULL)
+    if (conn == NULL || conn->request == NULL)
       close_connection((uv_handle_t*) stream);
     return;
   }
@@ -571,60 +579,104 @@ on_read(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
   /* One request per connection at a time.  Anything arriving while one is in
    * flight -- a pipelined request, or garbage -- is ignored: serving it would
    * give the connection a second owner, and whichever finished first would
-   * close the handle out from under the other.  A second request in a single
-   * read is already dropped, since the target is parsed only once. */
-  if (stream->data != NULL) {
+   * close the handle out from under the other. */
+  if (conn == NULL || conn->request != NULL) {
     free(buf->base);
+    return;
+  }
+
+  if (conn->len + (size_t) nread > MAX_REQUEST_HEAD) {
+    free(buf->base);
+    fprintf(stderr, "Request head too large\n");
+    response_error((uv_handle_t*) stream, 431, "Request Header Fields Too Large", NULL);
+    close_connection((uv_handle_t*) stream);
+    return;
+  }
+
+  if (conn->len + (size_t) nread > conn->cap) {
+    size_t cap = conn->cap ? conn->cap : 8192;
+    char* grown;
+    while (cap < conn->len + (size_t) nread)
+      cap *= 2;
+    grown = realloc(conn->buf, cap);
+    if (grown == NULL) {
+      free(buf->base);
+      fprintf(stderr, "Allocate error: %s\n", strerror(errno));
+      close_connection((uv_handle_t*) stream);
+      return;
+    }
+    conn->buf = grown;
+    conn->cap = cap;
+  }
+  memcpy(conn->buf + conn->len, buf->base, (size_t) nread);
+  conn->len += (size_t) nread;
+  free(buf->base);
+
+  /* Parsed into locals first: an incomplete head has to be able to return
+   * without having allocated a request. */
+  const char* method;
+  size_t method_len;
+  const char* path;
+  size_t path_len;
+  int minor_version;
+  struct phr_header headers[32];
+  size_t num_headers = sizeof(headers) / sizeof(headers[0]);
+  int nparsed = phr_parse_request(
+          conn->buf,
+          conn->len,
+          &method,
+          &method_len,
+          &path,
+          &path_len,
+          &minor_version,
+          headers,
+          &num_headers,
+          conn->last_len);
+  if (nparsed == -2) {
+    /* Not a whole head yet; keep it and wait for the rest. */
+    conn->last_len = conn->len;
+    return;
+  }
+  if (nparsed < 0) {
+    conn->len = conn->last_len = 0;
+    fprintf(stderr, "Invalid request\n");
+    response_error((uv_handle_t*) stream, 400, "Bad Request", NULL);
+    close_connection((uv_handle_t*) stream);
     return;
   }
 
   http_request* request = calloc(1, sizeof(http_request));
   if (request == NULL) {
-    free(buf->base);
     fprintf(stderr, "Allocate error: %s\n", strerror(errno));
     close_connection((uv_handle_t*) stream);
     return;
   }
-
   request->handle = (uv_handle_t*) stream;
-
-  request->num_headers = sizeof(request->headers) / sizeof(request->headers[0]);
-  int nparsed = phr_parse_request(
-          buf->base,
-          nread,
-          &request->method,
-          &request->method_len,
-          &request->path,
-          &request->path_len,
-          &request->minor_version,
-          request->headers,
-          &request->num_headers,
-          0);
-  if (nparsed < 0) {
-    free(request);
-    free(buf->base);
-    fprintf(stderr, "Invalid request\n");
-    close_connection((uv_handle_t*) stream);
-    return;
-  }
-  /* From here on this request owns the connection. */
-  stream->data = request;
-  /*
-  int cl = content_length(request);
-  if (cl >= 0 && cl < buf->len - nparsed) {
-    free(request);
-    free(buf->base);
-    return;
-  }
-  */
+  request->method = method;
+  request->method_len = method_len;
+  request->path = path;
+  request->path_len = path_len;
+  request->minor_version = minor_version;
+  memcpy(request->headers, headers, sizeof(headers));
+  request->num_headers = num_headers;
   /* TODO: handle reading whole payload */
-  request->payload = buf->base + nparsed;
-  request->payload_len = buf->len - nparsed;
+  request->payload = conn->buf + nparsed;
+  request->payload_len = conn->len - (size_t) nparsed;
+
+  /* From here on this request owns the connection.  Its path and headers point
+   * into conn->buf, which stays allocated; the buffer is only rewritten by a
+   * later read, and reads are ignored while a request is in flight. */
+  conn->request = request;
+  conn->len = conn->last_len = 0;
   request_complete(request);
-  free(buf->base);
 }
 
 static void on_close(uv_handle_t* peer) {
+  http_connection* conn = (http_connection*) peer->data;
+  if (conn) {
+    free(conn->buf);
+    free(conn);
+  }
   free(peer);
 }
 
@@ -707,12 +759,18 @@ on_connection(uv_stream_t* server, int status) {
     fprintf(stderr, "Allocate error: %s\n", strerror(errno));
     return;
   }
-  /* No request in flight yet; see on_read(). */
-  stream->data = NULL;
+  stream->data = calloc(1, sizeof(http_connection));
+  if (stream->data == NULL) {
+    fprintf(stderr, "Allocate error: %s\n", strerror(errno));
+    free(stream);
+    return;
+  }
 
   r = uv_tcp_init(loop, (uv_tcp_t*) stream);
   if (r) {
     fprintf(stderr, "Socket creation error: %s: %s\n", uv_err_name(r), uv_strerror(r));
+    free(stream->data);
+    free(stream);
     return;
   }
 

--- a/server.h
+++ b/server.h
@@ -47,6 +47,18 @@ typedef struct _http_request {
   char file_path[PATH_MAX];
 } http_request;
 
+/* Per connection state, hung off the handle's data pointer.  A request can
+ * arrive across several reads, so the bytes seen so far are accumulated here;
+ * `request` is the one currently being served, or NULL when the connection is
+ * idle and therefore unowned. */
+typedef struct {
+  char* buf;
+  size_t len;
+  size_t cap;
+  size_t last_len;
+  struct _http_request* request;
+} http_connection;
+
 typedef struct {
   uv_file fd;
   uv_write_t write_req;

--- a/test/smoke.py
+++ b/test/smoke.py
@@ -163,6 +163,49 @@ def main():
                             (b"/%2Fetc/passwd", "encoded separator, upper case")):
             check(f"{why} is 400", status(port, target).startswith("HTTP/1.0 400"), True)
 
+        print("requests arriving in pieces")
+
+        def in_pieces(parts):
+            s = socket.socket()
+            s.settimeout(3)
+            try:
+                s.connect(("127.0.0.1", port))
+                for part in parts:
+                    s.sendall(part)
+                    time.sleep(0.05)
+                data = b""
+                while b"\r\n\r\n" not in data:
+                    chunk = s.recv(65536)
+                    if not chunk:
+                        return "<closed>"
+                    data += chunk
+                return data.split(b"\r\n", 1)[0].decode("latin-1")
+            except OSError:
+                return "<error>"
+            finally:
+                s.close()
+
+        check("header terminator in its own packet",
+              in_pieces([b"GET /index.html HTTP/1.1\r\nHost: x\r\n", b"\r\n"]),
+              "HTTP/1.1 200 OK")
+        check("request line split mid-target",
+              in_pieces([b"GET /index.h", b"tml HTTP/1.1\r\nHost: x\r\n\r\n"]),
+              "HTTP/1.1 200 OK")
+        check("one header per packet",
+              in_pieces([b"GET /index.html HTTP/1.1\r\n", b"Host: x\r\n",
+                         b"User-Agent: t\r\n", b"\r\n"]),
+              "HTTP/1.1 200 OK")
+        check("byte at a time",
+              in_pieces([bytes([c]) for c in b"GET / HTTP/1.1\r\nHost: x\r\n\r\n"]),
+              "HTTP/1.1 200 OK")
+        # A client must not be able to make the server buffer without bound.
+        check("oversized head is refused",
+              in_pieces([b"GET / HTTP/1.1\r\nHost: x\r\n",
+                         b"X: " + b"v" * 60000 + b"\r\n",
+                         b"Y: " + b"v" * 60000 + b"\r\n\r\n"]),
+              "HTTP/1.0 431 Request Header Fields Too Large")
+        check("still alive after that", proc.poll(), None)
+
         print("Connection header matching")
 
         def conn(extra, version=b"1.1"):


### PR DESCRIPTION
`on_read()` parsed only the bytes of a single read and treated picohttpparser's `-2` (incomplete) the same as `-1` (malformed), so any request that did not arrive in one read was dropped and the connection closed with no response. `http_request` even carries a `last_len` field for incremental parsing that was never written, with `0` hardcoded as the argument.

This is not a corner case — it is whatever TCP happens to do. Against master:

```
header terminator in its own packet  -> connection closed, no response
request line split mid-target        -> connection closed, no response
one header per packet                -> connection closed, no response
a byte at a time                     -> connection closed, no response
```

The server logged `Invalid request` for each.

A connection now carries its own state in a new `http_connection`, hung off the handle's `data`: the bytes accumulated so far, how many of them the parser has already scanned, and the request in flight. `-2` keeps the buffer and returns to wait for more; `-1` answers 400 rather than closing silently. `last_len` is passed so the parser does not rescan what it has already seen.

`stream->data` previously doubled as the in-flight-request marker from #7 and #9; that role moves to `conn->request`, and the invariant is unchanged — a connection with no request in flight is unowned and closed by `on_read()`, one with a request is closed by its owner.

Buffering needs a bound or it becomes a memory exhaustion vector, so the head is capped at 64 KiB and a client that exceeds it gets 431 and is closed.

`payload_len` is fixed on the way past: it was `buf->len - nparsed`, using the *allocated* size of the read buffer, which libuv sets to its 64 KiB suggested size rather than the number of bytes received. It now uses the accumulated length. `payload` also points into a buffer that outlives the read, instead of one freed at the end of `on_read()`.

Verified: the five new smoke cases fail on master and pass here, on a plain build and on ASan/UBSan with LeakSanitizer enabled. The fuzzer is clean over 3000 targets. Separately stress tested with 10 concurrent clients doing 40 connections each, mixing byte-at-a-time sends that abandon mid-request, 40 KiB headers split across writes, garbage arriving during a transfer, and keep-alive connections whose second request is split: no sanitizer diagnostics, no leaks at exit, descriptors back to baseline, server still serving. Analyzer baseline unchanged at 9.