### PR TITLE
Validate the port argument before narrowing it to an int

### DIFF
--- a/server.c
+++ b/server.c
@@ -832,9 +832,16 @@ main(int argc, char* argv[]) {
     } else
     if (!strcmp(argv[i], "-p")) {
       if (i == argc-1) usage(argv[0]);
+      /* Range checked as a long, before narrowing: assigning to an int first
+       * lets a value like 4294967296 truncate to something that passes. */
+      const char* arg = argv[++i];
       char* e = NULL;
-      port = strtol(argv[++i], &e, 10);
-      if ((e && *e) || port < 0 || port > 65535) usage(argv[0]);
+      long value;
+      errno = 0;
+      value = strtol(arg, &e, 10);
+      if (e == arg || *e || errno != 0 || value < 0 || value > 65535)
+        usage(argv[0]);
+      port = (int) value;
     } else
     if (!strcmp(argv[i], "-d")) {
       if (i == argc-1) usage(argv[0]);

--- a/test/smoke.py
+++ b/test/smoke.py
@@ -122,6 +122,19 @@ def main():
     with open(os.path.join(tmp, "secret.txt"), "w") as f:
         f.write(CANARY + "\n")
 
+    print("rejecting bad arguments")
+    for bad in ("4294967296", "", "65536", "-1", "abc", "80x", "0x50"):
+        # Must exit non-zero rather than silently binding some other port. A
+        # binary that accepts the value keeps running, so a timeout counts as
+        # not refused rather than as an error in the test.
+        try:
+            done = subprocess.run([binary, "-a", "127.0.0.1", "-p", bad, "-d", root],
+                                  capture_output=True, timeout=5)
+            refused = done.returncode != 0
+        except subprocess.TimeoutExpired:
+            refused = False
+        check(f"-p {bad!r} is refused", refused, True)
+
     port = free_port()
     log = open(os.path.join(tmp, "server.log"), "w+")
     proc = subprocess.Popen(


### PR DESCRIPTION
`strtol`'s result was assigned to the `int` `port` and only then range checked, so a value that does not fit truncated into something that passed. An empty argument was accepted too, because `strtol` consumes nothing and leaves `*e` at the terminator.

Against master:

```
-p 4294967296  ->  Listening 127.0.0.1:0     silently bound an ephemeral port
-p ''          ->  Listening 127.0.0.1:0     same
-p 65536       ->  usage                      already correct
-p abc         ->  usage                      already correct
```

Binding a port the operator did not ask for is worse than refusing to start: the server looks healthy and is reachable at an address nobody knows.

Now the value is kept as a `long`, and the argument is rejected if `strtol` consumed nothing, if anything follows the digits, if `errno` was set, or if the value is outside 0-65535 — before it is narrowed. The `99999999999999999999` case happened to be caught already, but only because `LONG_MAX` narrowed to a negative `int` on this platform, which is not something to rely on.

The smoke test grows an argument-validation phase that runs before the server is started. A binary that wrongly accepts the value keeps running rather than exiting, so a timeout is counted as "not refused" instead of erroring the test. It fails on master with the two mismatches above.