### PR TITLE
Handle failures on paths that cannot be reached from a request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       # BASELINE as findings are fixed.
       - name: Static analysis
         env:
-          BASELINE: 9
+          BASELINE: 6
         run: |
           clang --analyze -Xanalyzer -analyzer-output=text \
             -Wall -Wextra -Wno-unused-parameter -Wno-unused-function \

--- a/server.c
+++ b/server.c
@@ -179,8 +179,10 @@ on_write(uv_write_t* req, int status) {
   if (r) {
     fprintf(stderr, "File read error: %s: %s\n", uv_err_name(r), uv_strerror(r));
     response_error(response->handle, 500, "Internal Server Error", NULL);
-    response->request = NULL;
-    destroy_response(response, 0);
+    /* The transfer is over, so the request goes with the response and the
+     * connection is closed; nulling it out here leaked the request and left
+     * the connection open with nothing left to serve it. */
+    destroy_response(response, 1);
   }
 }
 
@@ -774,23 +776,25 @@ on_connection(uv_stream_t* server, int status) {
     return;
   }
 
-  r = uv_tcp_simultaneous_accepts((uv_tcp_t*) stream, 1);
-  if (r) {
-    fprintf(stderr, "Flag error: %s: %s\n", uv_err_name(r), uv_strerror(r));
-    return;
-  }
-
+  /* Accept before anything else can fail: returning from this callback without
+   * having accepted makes libuv stop watching the listening socket, and only
+   * uv_accept() ever starts it again, so the server would take no further
+   * connections at all. */
   r = uv_accept(server, stream);
   if (r) {
     fprintf(stderr, "Accept error: %s: %s\n", uv_err_name(r), uv_strerror(r));
+    close_connection((uv_handle_t*) stream);
     return;
   }
 
-  r = uv_tcp_nodelay((uv_tcp_t*) stream, 1);
-  if (r) {
+  /* Neither flag is worth dropping a connection over. */
+  r = uv_tcp_simultaneous_accepts((uv_tcp_t*) stream, 1);
+  if (r)
     fprintf(stderr, "Flag error: %s: %s\n", uv_err_name(r), uv_strerror(r));
-    return;
-  }
+
+  r = uv_tcp_nodelay((uv_tcp_t*) stream, 1);
+  if (r)
+    fprintf(stderr, "Flag error: %s: %s\n", uv_err_name(r), uv_strerror(r));
 
   r = uv_read_start(stream, on_alloc, on_read);
   if (r) {
@@ -812,6 +816,11 @@ static void
 add_mime_type(const char* ext, const char* value) {
   int hr;
   khint_t k = kh_put(mime_type, mime_type, ext, &hr);
+  /* On failure kh_put returns kh_end(), which is not a slot to write to. */
+  if (hr < 0) {
+    fprintf(stderr, "Allocate error: %s\n", ext);
+    return;
+  }
   kh_value(mime_type, k) = value;
 }
 
@@ -859,6 +868,10 @@ main(int argc, char* argv[]) {
   int r;
 
   mime_type = kh_init(mime_type);
+  if (mime_type == NULL) {
+    fprintf(stderr, "Allocate error: %s\n", strerror(errno));
+    return 1;
+  }
   add_mime_type(".jpg", "image/jpeg");
   add_mime_type(".png", "image/png");
   add_mime_type(".gif", "image/gif");


### PR DESCRIPTION
Four defects on error paths. To be clear up front: **none of these is reproducible from outside**, so unlike the earlier fixes there is no before/after transcript. They are fixed as code defects, and the static analyzer count drops from 9 to 6, so the CI ratchet is tightened to match.

**`on_connection()` could stop the server accepting connections at all.** libuv's `uv__server_io()` ends with:

```c
stream->connection_cb(stream, 0);
if (stream->accepted_fd != -1)
  /* The user hasn't yet accepted called uv_accept() */
  uv__io_stop(loop, &stream->io_watcher, POLLIN);
```

and the watcher is only started again inside `uv_accept()`. So returning from the connection callback without accepting stops the listener permanently. `uv_tcp_simultaneous_accepts` failing did exactly that, and leaked the handle as well. `uv_accept` is now called first, and the two socket flags are logged but no longer treated as fatal — neither is worth dropping a connection over, let alone the listener. The `uv_accept` failure path now closes the handle instead of leaking it.

I tried to reach the old `uv_accept` failure path by exhausting descriptors with `ulimit -n 64` and 400 concurrent connections. It is not reachable: libuv handles `EMFILE`/`ENFILE` itself in `uv__emfile_trick()` and returns before ever calling the connection callback, so `Accept error` never appeared.

**`on_write()` leaked a request and stranded a connection.** On a `uv_fs_read` submission failure it did `response->request = NULL` before `destroy_response(response, 0)`, so `destroy_request()` was never reached — the request was never freed, and with `close_handle` 0 the connection stayed open with nothing left to serve it. It now hands the request to `destroy_response` and closes.

**`add_mime_type()` wrote through a failed `kh_put`.** On failure `kh_put` returns `kh_end()`, which is not a slot; `kh_value(...) = value` then wrote out of bounds. The return code is checked now.

**`kh_init` was assumed to succeed** in `main`. Checked, and startup fails cleanly.

Verified that nothing regressed: smoke and fuzz clean on a plain build and on ASan/UBSan with LeakSanitizer enabled.