### PR TITLE
Send the response header synchronously when the socket takes it

### DIFF
--- a/server.c
+++ b/server.c
@@ -114,6 +114,7 @@ btime(int f) {
 
 static void on_write(uv_write_t*, int);
 static void on_write_header(uv_write_t*, int);
+static void start_body(http_response*);
 static void on_write_error_free_buf(uv_write_t*, int);
 static void on_read(uv_stream_t*, ssize_t, const uv_buf_t*);
 static void on_close(uv_handle_t*);
@@ -277,20 +278,41 @@ on_fs_open(uv_fs_t* req) {
     return;
   }
 
-  /* uv_write() keeps the buffer, so the header cannot live on this frame; it
-   * also has its own request, because response->write_req is still in use for
+  uv_buf_t buf = uv_buf_init(bufline, nbuf);
+  int written = 0;
+
+#ifndef _WIN32
+  /* A header this small almost always leaves in one synchronous write, which
+   * saves an allocation and a trip round the loop per response.  uv_try_write
+   * is safe with a stack buffer precisely because it does not queue. */
+  r = uv_try_write((uv_stream_t*) request->handle, &buf, 1);
+  if (r == nbuf) {
+    start_body(response);
+    return;
+  }
+  if (r > 0)
+    written = r;
+  else if (r < 0 && r != UV_EAGAIN) {
+    fprintf(stderr, "Write error: %s: %s\n", uv_err_name(r), uv_strerror(r));
+    destroy_response(response, 1);
+    return;
+  }
+#endif
+
+  /* Whatever is left has to be queued, so it needs a buffer that outlives this
+   * frame, and its own request, because response->write_req is still in use for
    * the body chunks. */
-  response->header = malloc(nbuf);
+  response->header = malloc(nbuf - written);
   if (response->header == NULL) {
     fprintf(stderr, "Allocate error: %s\n", strerror(errno));
     response_error(request->handle, 500, "Internal Server Error", NULL);
     destroy_response(response, 1);
     return;
   }
-  memcpy(response->header, bufline, nbuf);
+  memcpy(response->header, bufline + written, nbuf - written);
   response->header_req.data = response;
 
-  uv_buf_t buf = uv_buf_init(response->header, nbuf);
+  buf = uv_buf_init(response->header, nbuf - written);
   r = uv_write(&response->header_req, (uv_stream_t*) request->handle, &buf, 1, on_write_header);
   if (r) {
     fprintf(stderr, "Write error: %s: %s\n", uv_err_name(r), uv_strerror(r));
@@ -300,6 +322,21 @@ on_fs_open(uv_fs_t* req) {
 
 /* The body is only read once the header has actually gone out, so a partial or
  * failed header write cannot be followed by body bytes. */
+static void
+start_body(http_response* response) {
+  /* A HEAD response is the header and nothing else. */
+  if (response->request->head_only) {
+    destroy_response(response, !response->request->keep_alive);
+    return;
+  }
+
+  int r = uv_fs_read(loop, &response->read_req, response->fd, &response->buf, 1, -1, on_fs_read);
+  if (r) {
+    fprintf(stderr, "File read error: %s: %s\n", uv_err_name(r), uv_strerror(r));
+    destroy_response(response, 1);
+  }
+}
+
 static void
 on_write_header(uv_write_t* req, int status) {
   http_response* response = (http_response*) req->data;
@@ -313,17 +350,7 @@ on_write_header(uv_write_t* req, int status) {
     return;
   }
 
-  /* A HEAD response is the header and nothing else. */
-  if (response->request->head_only) {
-    destroy_response(response, !response->request->keep_alive);
-    return;
-  }
-
-  int r = uv_fs_read(loop, &response->read_req, response->fd, &response->buf, 1, -1, on_fs_read);
-  if (r) {
-    fprintf(stderr, "File read error: %s: %s\n", uv_err_name(r), uv_strerror(r));
-    destroy_response(response, 1);
-  }
+  start_body(response);
 }
 
 /*


### PR DESCRIPTION
#11 moved the response header from `uv_try_write` to `uv_write`, which fixed a real lifetime bug — the buffer was on the stack, and `uv_write` does not copy — but it also put a `malloc` and a full trip round the event loop in the path of every response. That costs throughput, which matters for a repository whose README leads with a benchmark.

Measured with `ab -k -c 10 -n 20000` against a 32 byte file, three builds interleaved, 10 trials each, medians (this is WSL2 on a shared machine, so the run-to-run spread is wide and `ab` occasionally reports a negative rate, which is discarded):

```
f843caf (before any of this work)   18866 req/s   range 16023-19822
current master                      16905 req/s   range 11973-17796    89.6%
this PR                             18635 req/s   range 17988-19140    98.8%
```

Pairwise, this PR beat current master in 7 of 8 trials in an earlier round as well, so the async header write was the regression and this recovers essentially all of it.

The fix keeps the correctness of #11 rather than reverting it. `uv_try_write` is safe with a stack buffer *because* it does not queue: it either writes now or it does not. So the header is offered to the socket from the stack first, and only what is left over — a short write, or `UV_EAGAIN` — is copied to a heap buffer owned by the response and queued with `uv_write`. A response header is a couple of hundred bytes, so the common case is one synchronous write, no allocation, and no extra loop iteration; the slow path is still handled correctly instead of being ignored, which is what was wrong before #11.

Starting the body read is factored into `start_body()` so both paths use it, and the `_WIN32` branch simply skips the fast path and queues as it does today.

Verified: smoke and fuzz clean on a plain build and on ASan/UBSan with LeakSanitizer enabled, so the conditional allocation is checked on both paths.